### PR TITLE
Fix storing of `expires_at` for OAuth tokens

### DIFF
--- a/app/Models/OauthConnection.php
+++ b/app/Models/OauthConnection.php
@@ -20,7 +20,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
  * @property Collection<string, mixed> $data
  * @property string|null $token
  * @property string|null $refresh_token
- * @property string|null $expires_at
+ * @property CarbonImmutable|null $expires_at
  * @property CarbonImmutable|null $created_at
  * @property CarbonImmutable|null $updated_at
  * @property-read User $user
@@ -56,6 +56,7 @@ final class OauthConnection extends Model
      */
     protected $casts = [
         'data' => AsCollection::class,
+        'expires_at' => 'datetime',
     ];
 
     /**


### PR DESCRIPTION
This pull request fixes an issue where the `expires_at` field was not properly stored when connecting to OAuth providers.

Although the field is defined as a timestamp in the database, it was previously not cast correctly in the model, causing Laravel to treat it as a string. As a result, expiration times like `now()->addSeconds(7200)` were not saved properly.

**Changes:**
- Added `'expires_at' => 'datetime'` to the `$casts` array in the `OauthSocialConnection` model.
- Updated the PHPDoc type of `expires_at` to `CarbonImmutable`.

This ensures correct handling and saving of the expiration timestamp for all OAuth providers. The fix has been tested specifically with Twitter (X).